### PR TITLE
add endpoint to fetch latest version

### DIFF
--- a/main.go
+++ b/main.go
@@ -54,6 +54,7 @@ func main() {
 	r.HandleFunc("/healthz", handlers.Healthz)
 	r.HandleFunc("/{project}", handlers.InstallScript)
 	r.HandleFunc("/{owner}/{project}", handlers.InstallScript)
+	r.HandleFunc("/{owner}/{project}/latest", handlers.GetLatestVersion)
 
 	if err := http.ListenAndServe(fmt.Sprintf(":%d", port), r); err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
KOTS CLI currently utilizes the `kots.io/install?version` endpoint (with the `version` query param) to determine if an update is available.  This was previously hard-coded into the Cloudflare worker that sits in front of this service.  In order to remove that, an endpoint was added here to provide the same functionality.